### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This helps editors get on the same page for a few very basic style options. See https://editorconfig.org/
Eg it helps avoid noise like this: 
<img width="1225" alt="Screenshot 2021-08-27 at 12 26 35" src="https://user-images.githubusercontent.com/86618292/131113438-2f7bb3f3-6a0e-4aa4-b549-c73edda3d913.png">

Not sure why I'm only allowed to request one reviewer. 😕 @rowdyear 